### PR TITLE
FEAT!: Password expiration now work

### DIFF
--- a/src/main/java/org/spine/iquestionapi/model/User.java
+++ b/src/main/java/org/spine/iquestionapi/model/User.java
@@ -83,4 +83,6 @@ public class User {
     @Column(nullable = false)
     private Role role;
 
+    @Column(nullable = false)
+    private long passwordChangeTime = 0;
 }


### PR DESCRIPTION
Issue #32 Fixed with this one aswell as task 34 on the taiga board.




Work flow:
After registration date is set to 0; Since the diffirence with the current time will always be higher then 90 days (Sicne its counting from unix 0).

When user logs in for the first time they will be prompted that there password has expired. Auto generated a new token to their email so in FE they will be sent to the change password screen where they can change it with the token they have just recieved in their inbox. After changing password gets set to current time on api