### PR TITLE
Fix/requestpasswordreset

### DIFF
--- a/src/main/java/org/spine/iquestionapi/controller/AuthController.java
+++ b/src/main/java/org/spine/iquestionapi/controller/AuthController.java
@@ -111,7 +111,7 @@ public class AuthController {
 
             long ninetyDaysInMilliseconds = 7776000000L;
             if(user.getPasswordChangeTime() <= ninetyDaysInMilliseconds){
-                requestPasswordReset(body.getEmail());
+                requestPasswordReset(new RequestPasswordResetBody(user.getEmail()));
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Password has to be reset");
             }
 
@@ -126,14 +126,14 @@ public class AuthController {
     /**
      * Request a password reset
      *
-     * @param email the email of the user
+     * @param requestPasswordResetBody a RequestPasswordResetBody containing the users email
      * @return success message
      */
     @PostMapping("/request-password-reset")
     @ResponseBody
-    public Map<String, Object> requestPasswordReset(@RequestBody String email) {
+    public Map<String, Object> requestPasswordReset(@RequestBody RequestPasswordResetBody requestPasswordResetBody) {
         // Get user from email
-        User user = userRepo.findByEmail(email)
+        User user = userRepo.findByEmail(requestPasswordResetBody.getEmail())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Email not found"));
 
         // Check if user already has token

--- a/src/main/java/org/spine/iquestionapi/model/RequestPasswordResetBody.java
+++ b/src/main/java/org/spine/iquestionapi/model/RequestPasswordResetBody.java
@@ -1,0 +1,17 @@
+package org.spine.iquestionapi.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestPasswordResetBody {
+  /**
+   * The email of the user
+   */
+  private String email;
+}


### PR DESCRIPTION
## Omschrijving
 
de endpoint request-password-reset werkt nu met een normale body in plaats van alleen de email
Voorbeeld
Voorheen:
```json
"email@domain.com"
```
NU:
```json
{
    "email": "email@domain.com"
}
 ```
## How-to-demo
 
1. Beschrijf hier in een duidelijk stappenplan hoe dit pull request getest moet worden.
- 1: start api op
- 2: request password reset via auth/request-password-reset
 
## Checklist
 
Loop alle onderstaande punten na en zet een `x` in alle vakjes die van toepassing zijn.
 
- [ ] Mijn pull request is voor één story/feature.
- [x] Elke individuele commit in dit pull request is logisch.
- [x] Alle code, documentatie en commits zijn in het Engels.
- [x] Ik heb overbodige/ongebruikte code weggegooid.
- [x] Mijn pull-request verwerkt geen nieuwe gevoelige informatie zonder dat ik dit heb doorgesproken met een lid van het security-team.
- [ ] Ik heb tests toegevoegd of bijgewerkt om mijn wijzigingen te testen.
- [x] Als mijn wijziging veranderingen in de documentatie vereist, dan heb ik dat bijgewerkt.