### PR TITLE
Fix!: Login now also gives user data

### DIFF
--- a/src/main/java/org/spine/iquestionapi/controller/AuthController.java
+++ b/src/main/java/org/spine/iquestionapi/controller/AuthController.java
@@ -116,7 +116,10 @@ public class AuthController {
 
             String token = jwtUtil.generateToken(body.getEmail());
 
-            return Collections.singletonMap("token", token);
+            return Map.of(
+                    "token", token,
+                    "user", user
+            );
         } catch (AuthenticationException authExc) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS");
         }

--- a/src/main/java/org/spine/iquestionapi/model/User.java
+++ b/src/main/java/org/spine/iquestionapi/model/User.java
@@ -70,6 +70,7 @@ public class User {
     /**
      * The state of activation of the account
      */
+    @JsonIgnore
     private boolean enabled = false;
     /**
      * The entries a user filled in
@@ -87,5 +88,6 @@ public class User {
     private Role role;
 
     @Column(nullable = false)
+    @JsonIgnore
     private long passwordChangeTime = 0;
 }


### PR DESCRIPTION
Now returns like follows:
```
{
    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJVc2VyIERldGFpbHMiLCJpc3MiOiJJLlF1ZXN0aW9uIiwiaWF0IjoxNjcxNzAxNDQ0LCJlbWFpbCI6InMxMTM2NjQ0QHN0dWRlbnQuaHNsZWlkZW4ubmwifQ.RzP9YO_jBYBM2ylCl6cBRcuCMHqmRM14zIO61uSfnoU",
    "user": {
        "id": "d7a818c7-5c5d-404a-9685-8d0c909fca20",
        "name": "Stan Smits",
        "email": "s1136644@student.hsleiden.nl",
        "organization": "HS Leiden",
        "role": "SPINE_ADMIN"
    }
}
```